### PR TITLE
create test for throwing exception from exit overload

### DIFF
--- a/tests/051.phpt
+++ b/tests/051.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test exit overload with exception
+--INI--
+uopz.overloads=1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+class ExitException extends RuntimeException {}
+
+uopz_overload(ZEND_EXIT, function($status = null){
+	throw new ExitException("exit. STATUS=$status");
+	return ZEND_USER_OPCODE_RETURN;
+});
+
+class Test {
+	public function method() {
+		exit(10);
+	}
+}
+
+class Unit {
+	public function test() {
+		$test = new Test();
+		try {
+			$test->method();
+		} catch(ExitException $e) {
+			echo "exit caught";
+		}
+		
+		return true;
+	} 
+}
+$unit = new Unit();
+var_dump($unit->test());
+uopz_overload(ZEND_EXIT, null);
+var_dump($unit->test());
+echo "failed";
+?>
+--EXPECT--
+exit caught
+bool(true)


### PR DESCRIPTION
I tried with the latest git master and php 5.6 (no xdebug), but it seems that my use case of throwing an exception from an exit overload is broken.
I have added a test file to let you easily reproduce it, but unfortunately I have no real experience in C programming or the PHP/ZEND API, so I probably won't be able to make this work on my own...