### PR TITLE
segfaults fixes

### DIFF
--- a/copy.h
+++ b/copy.h
@@ -207,7 +207,7 @@ static inline zend_function* uopz_copy_user_function(zend_class_entry *clazz, ze
 
 	op_array->function_name = zend_string_dup(op_array->function_name, 0);
 	op_array->refcount = emalloc(sizeof(uint32_t));
-	(*op_array->refcount) = 2;
+	(*op_array->refcount) = 1;
 
 	op_array->fn_flags &= ~ ZEND_ACC_CLOSURE;	
 	op_array->fn_flags |= ZEND_ACC_ARENA_ALLOCATED;


### PR DESCRIPTION
We have large codebase with many tricky tests and constantly facing segfaults with php7. Here's fix for Your reviewal.
What was fixed:
- crash on exit when attempting to replace backed-up function of extension (memcached in my case) with copied one.
- crash when destroying previous function upon replacing, which was already destroyed somewhere
