### PR TITLE
fix check protected

### DIFF
--- a/tests/052.phpt
+++ b/tests/052.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test protected check
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+class Test {
+	protected function one() {
+		return '321';
+	}
+
+	public function __call($name, $args) {
+		return $this->one();
+	}
+}
+
+uopz_function(Test::class, 'one', function() { return 'redefined'; });
+
+var_dump((new Test())->CallMagic());
+?>
+--EXPECT--
+string(9) "redefined"

--- a/uopz.c
+++ b/uopz.c
@@ -1290,6 +1290,7 @@ static zend_bool uopz_function(zend_class_entry *clazz, zend_string *name, zval 
 		return 0;
 	}
 
+	function->common.prototype = NULL;
 	function->common.fn_flags |= flags & ZEND_ACC_PPP_MASK;
 
 	if (flags & ZEND_ACC_STATIC) {


### PR DESCRIPTION
Fix for case with code like:
```php
class Test {
	protected function one() {
		return '321';
	}

	public function __call($name, $args) {
		return $this->one();
	}
}

uopz_function(Test::class, 'one', function() { return 'redefined'; });

var_dump((new Test())->CallMagic());
```
leading to infinite recursion __call -> one -> __call -> one ...
Thanks @axxapy