### PR TITLE
Fix #53: uopz_redefine() refuses to redefine a constant as array

### DIFF
--- a/src/constant.c
+++ b/src/constant.c
@@ -36,6 +36,7 @@ zend_bool uopz_constant_redefine(zend_class_entry *clazz, zend_string *name, zva
 		case IS_STRING:
 		case IS_TRUE:
 		case IS_FALSE:
+		case IS_ARRAY:
 		case IS_RESOURCE:
 		case IS_NULL:
 			break;

--- a/tests/bugs/gh53.phpt
+++ b/tests/bugs/gh53.phpt
@@ -1,0 +1,25 @@
+--TEST--
+github #53
+--DESC--
+uopz_redefine() refuses to redefine a constant as array
+--FILE--
+<?php
+class testClass
+{
+    const ARR = [1, 2, 3];
+}
+
+uopz_redefine(testClass::class, 'ARR', [1, 2, 4]);
+var_dump(testClass::ARR);
+?>
+===DONE===
+--EXPECT--
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(4)
+}
+===DONE===


### PR DESCRIPTION
This limitation appears to be accidental, and we see no reason to stick
to it.