### PR TITLE
Fix #68: avoid infinite loop when mock with no-args constructor is called with arguments

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -335,6 +335,15 @@ int uopz_mock_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
 				if (EX(opline)->extended_value == 0 && 
 					(EX(opline)+1)->opcode == ZEND_DO_FCALL) {
 					EX(opline) += 2;
+				} else if ((EX(opline)+1)->extended_value == 0 && (EX(opline)+1)->opcode == ZEND_SEND_VAL_EX) {
+					// avoid infinite loop if the mock has a no-args constructor but the constructor receives args
+					int args_ctr = 1;
+
+					while ((EX(opline)+args_ctr)->opcode == ZEND_SEND_VAL_EX) {
+						args_ctr++;
+					}
+
+					EX(opline) += args_ctr + 1;
 				}
 #endif
 				UOPZ_VM_ACTION = ZEND_USER_OPCODE_CONTINUE;

--- a/tests/bugs/gh68.phpt
+++ b/tests/bugs/gh68.phpt
@@ -1,0 +1,39 @@
+--TEST--
+github #68: uopz_set_mock should not hang when mock with no-arg constructor is called with args
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class X {
+	public function foo() {
+		echo "X\n";
+	}
+}
+
+class Y {
+	public function foo() {
+		echo "Y\n";
+	}
+}
+
+uopz_set_mock(X::class, new class extends X {
+	public function __construct() {}
+
+	public function foo() {
+		echo "anonymous\n";
+	}
+});
+
+$x = new X(0,1,"test");
+$x->foo();
+
+uopz_unset_mock(X::class);
+uopz_set_mock(X::class, new Y);
+
+$x = new X(0);
+$x->foo();
+
+?>
+--EXPECT--
+anonymous
+Y


### PR DESCRIPTION
First of all—hello, and thank you for providing `uopz` to the PHP community, it's an invaluable tool when attempting to test legacy procedural code.

It seems that, as described in issue #68 , an infinite loop occurs on PHP 7.2 if a mock with a no-args constructor is set via `uopz_set_mock`, but is instantiated with one or more constructor arguments (PHP 7.0 does not experience this issue).

This PR attempts to provide a fix for this problem and provides a regression test. While all tests pass, I'm not sure if this is the kosher way to implement this so a review from someone with more experience would be greatly appreciated.

Thanks in advance! 🙂 

CC: @krakjoe 