### PR TITLE
fix call uopz_[s|g]et_property in a class, result a wrong fake_scope

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -139,7 +139,7 @@ zend_bool uopz_implement(zend_class_entry *clazz, zend_class_entry *interface) {
 } /* }}} */
 
 void uopz_set_property(zval *object, zval *member, zval *value) { /* {{{ */
-	zend_class_entry *scope = uopz_get_scope(1);
+	zend_class_entry *scope = uopz_get_scope(0);
 	zend_class_entry *ce = Z_OBJCE_P(object);
 	zend_property_info *info;
 
@@ -168,7 +168,7 @@ void uopz_set_property(zval *object, zval *member, zval *value) { /* {{{ */
 } /* }}} */
 
 void uopz_get_property(zval *object, zval *member, zval *value) { /* {{{ */
-	zend_class_entry *scope = uopz_get_scope(1);
+	zend_class_entry *scope = uopz_get_scope(0);
 	zend_class_entry *ce = Z_OBJCE_P(object);
 	zend_property_info *info;
 	zval *prop, rv;
@@ -204,7 +204,7 @@ void uopz_get_property(zval *object, zval *member, zval *value) { /* {{{ */
 } /* }}} */
 
 void uopz_set_static_property(zend_class_entry *ce, zend_string *property, zval *value) { /* {{{ */
-	zend_class_entry *scope = uopz_get_scope(1);
+	zend_class_entry *scope = uopz_get_scope(0);
 	zend_class_entry *seek = ce;
 	zend_property_info *info;
 	zval *prop;
@@ -240,7 +240,7 @@ void uopz_set_static_property(zend_class_entry *ce, zend_string *property, zval 
 } /* }}} */
 
 void uopz_get_static_property(zend_class_entry *ce, zend_string *property, zval *value) { /* {{{ */
-	zend_class_entry *scope = uopz_get_scope(1);
+	zend_class_entry *scope = uopz_get_scope(0);
 	zend_class_entry *seek = ce;
 	zend_property_info *info;
 	zval *prop;

--- a/tests/bugs/0003-uopz_get_property.phpt
+++ b/tests/bugs/0003-uopz_get_property.phpt
@@ -1,0 +1,29 @@
+--TEST--
+call uopz_get_property in a class scope
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+    private $name = 'hello';
+
+    public function getName() {
+        return $this->name;
+    }
+}
+
+class UM {
+    public function getProp($obj, $name) {
+        uopz_get_property($obj, $name);
+    }
+}
+
+$f = new Foo();
+
+$um = New UM();
+$um->getProp($f, 'name');
+
+echo $f->getName();
+?>
+--EXPECT--
+hello

--- a/tests/bugs/0004-uopz_set_property.phpt
+++ b/tests/bugs/0004-uopz_set_property.phpt
@@ -1,0 +1,29 @@
+--TEST--
+call uopz_set_property in a class scope
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+    private $name = 'hello';
+
+    public function getName() {
+        return $this->name;
+    }
+}
+
+class UM {
+    public function setProp($obj, $name, $value) {
+        uopz_set_property($obj, $name, $value);
+    }
+}
+
+$f = new Foo();
+
+$um = New UM();
+$um->setProp($f, 'name', 'world');
+
+echo $f->getName();
+?>
+--EXPECT--
+world


### PR DESCRIPTION
Hi, thank you for provide so useful tools for php unit. 

But, I found some case not meeting expectations, i will describe it as clearly as possible in my poor english.

## My Environment

```
$ php -v
PHP 7.1.5 (cli) (built: Jun  7 2017 15:48:19) ( ZTS DEBUG )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies
```

```
$ php -i | grep 'uopz support' -C2
uopz

uopz support => enabled
Version => 5.0.2
```

## Case

### uopz_get_property

- Example code

```
<?php
class Foo {
    private $name = 'hello';

    public function getName() {
        return $this->name;
    }
}

class UM {
    public function getProp($obj, $name) {
        uopz_get_property($obj, $name);
    }
}

$f = new Foo();

$um = New UM();
$um->getProp($f, 'name');

echo $f->getName();
```

- Result

```
Fatal error: Uncaught Error: Cannot access private property Foo::$name in /path/to/uopz_get_property.php:6
Stack trace:
#0 /path/to/uopz_get_property.php(21): Foo->getName()
#1 {main}
  thrown in /path/to/uopz_get_property.php on line 6
```

### uopz_set_property

- Example code

```
<?php
class Foo {
    private $name = 'hello';

    public function getName() {
        return $this->name;
    }
}

class UM {
    public function setProp($obj, $name, $value) {
        uopz_set_property($obj, $name, $value);
    }
}

$f = new Foo();

$um = New UM();
$um->setProp($f, 'name', 'world');

echo $f->getName();
```

- Result

```
Fatal error: Uncaught Error: Cannot access private property Foo::$name in /path/to/uopz_set_property.php:6
Stack trace:
#0 /path/to/uopz_set_property.php(21): Foo->getName()
#1 {main}
  thrown in /path/to/uopz_set_property.php on line 6
```

This PR store the original value, after read and write property, restore orginal value.

Thanks.

CC @krakjoe 