### PR TITLE
Improve mocking (and all the things)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-    - 7.0
     - 7.1
     - 7.2
     - 7.3

--- a/package.xml
+++ b/package.xml
@@ -95,6 +95,16 @@ It supports the following activities:
      <file name="019.phpt" role="test" />
      <file name="020.phpt" role="test" />
      <file name="021.phpt" role="test" />
+     <file name="022.phpt" role="test" />
+     <file name="023.phpt" role="test" />
+     <file name="024.phpt" role="test" />
+     <file name="025.phpt" role="test" />
+     <file name="026.phpt" role="test" />
+     <file name="027.phpt" role="test" />
+     <file name="028.phpt" role="test" />
+     <file name="029.phpt" role="test" />
+     <file name="030.phpt" role="test" />
+     <file name="031.phpt" role="test" />
      <file name="skipif.inc" role="test" />
      <dir name="/bugs">
       <file name="0001-uopz_set_static.phpt" role="test" />
@@ -113,7 +123,7 @@ It supports the following activities:
  <dependencies>
   <required>
    <php>
-    <min>7.0.0</min>
+    <min>7.1.0</min>
    </php>
    <pearinstaller>
     <min>1.10</min>

--- a/src/class.h
+++ b/src/class.h
@@ -24,7 +24,8 @@ void uopz_unset_mock(zend_string *clazz);
 
 zend_bool uopz_extend(zend_class_entry *clazz, zend_class_entry *parent);
 zend_bool uopz_implement(zend_class_entry *clazz, zend_class_entry *interface);
-void uopz_get_mock(zend_string *clazz, zval *return_value);
+int uopz_get_mock(zend_string *clazz, zval *return_value);
+int uopz_find_mock(zend_string *clazz, zend_class_entry **mock);
 
 void uopz_set_property(zval *object, zval *member, zval *value);
 void uopz_get_property(zval *object, zval *member, zval *value);

--- a/src/copy.c
+++ b/src/copy.c
@@ -56,20 +56,7 @@ static inline zend_try_catch_element* uopz_copy_try(zend_try_catch_element *old,
 	return try_catch;
 } /* }}} */
 
-#if PHP_VERSION_ID < 70100
-/* {{{ */
-static inline zend_brk_cont_element* uopz_copy_brk(zend_brk_cont_element *old, int end) {
-	zend_brk_cont_element *brk_cont = safe_emalloc(end, sizeof(zend_brk_cont_element), 0);
-	
-	memcpy(
-		brk_cont,
-		old, 
-		sizeof(zend_brk_cont_element) * end);
-	
-	return brk_cont;
-} /* }}} */
-#else
-static inline zend_live_range* uopz_copy_live(zend_live_range *old, int end) {
+static inline zend_live_range* uopz_copy_live(zend_live_range *old, int end) { /* {{{ */
 	zend_live_range *range = safe_emalloc(end, sizeof(zend_live_range), 0);
 
 	memcpy(
@@ -78,8 +65,7 @@ static inline zend_live_range* uopz_copy_live(zend_live_range *old, int end) {
 		sizeof(zend_live_range) * end);
 
 	return range;
-}
-#endif
+} /* }}} */
 
 /* {{{ */
 static inline zval* uopz_copy_literals(zval *old, int end) {
@@ -251,15 +237,9 @@ zend_function* uopz_copy_closure(zend_class_entry *scope, zend_function *functio
 		op_array->arg_info = uopz_copy_arginfo(op_array, arg_info, op_array->num_args);
 	}
 
-#if PHP_VERSION_ID < 70100
-	if (op_array->brk_cont_array) {
-		op_array->brk_cont_array = uopz_copy_brk(op_array->brk_cont_array, op_array->last_brk_cont);
-	}
-#else
 	if (op_array->live_range) {
 		op_array->live_range = uopz_copy_live(op_array->live_range, op_array->last_live_range);
 	}
-#endif
 
 	if (op_array->try_catch_array) {
 		op_array->try_catch_array = uopz_copy_try(op_array->try_catch_array, op_array->last_try_catch);

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -22,8 +22,12 @@
 #include "php.h"
 #include "uopz.h"
 
+#include "class.h"
 #include "return.h"
 #include "hook.h"
+#include "util.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(uopz);
 
 #ifdef ZEND_VM_FP_GLOBAL_REG
 #	define UOPZ_OPCODE_HANDLER_ARGS
@@ -33,51 +37,14 @@
 #	define UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU execute_data
 #endif
 
-
-#if PHP_VERSION_ID >= 70100
-#	define RETURN_VALUE_USED(opline) ((opline)->result_type != IS_UNUSED)
-#else
-#	define RETURN_VALUE_USED(opline) (!((opline)->result_type & EXT_TYPE_UNUSED))
+#ifndef GC_ADDREF
+#define GC_ADDREF(g) ++GC_REFCOUNT(g)
 #endif
+
+#define RETURN_VALUE_USED(opline) ((opline)->result_type != IS_UNUSED)
 
 #if PHP_VERSION_ID >= 70300
 #	define EX_CONSTANT(e) RT_CONSTANT(EX(opline), e)
-#endif
-
-ZEND_EXTERN_MODULE_GLOBALS(uopz);
-
-int uopz_no_exit_handler(UOPZ_OPCODE_HANDLER_ARGS);
-int uopz_call_handler(UOPZ_OPCODE_HANDLER_ARGS);
-int uopz_constant_handler(UOPZ_OPCODE_HANDLER_ARGS);
-int uopz_mock_handler(UOPZ_OPCODE_HANDLER_ARGS);
-int uopz_fetch_handler(UOPZ_OPCODE_HANDLER_ARGS);
-int uopz_return_handler(UOPZ_OPCODE_HANDLER_ARGS);
-int uopz_add_class_handler(UOPZ_OPCODE_HANDLER_ARGS);
-#ifdef ZEND_FETCH_CLASS_CONSTANT
-int uopz_class_constant_handler(UOPZ_OPCODE_HANDLER_ARGS);
-#endif
-
-#if PHP_VERSION_ID >= 70300
-int uopz_add_mock_trait_handler(UOPZ_OPCODE_HANDLER_ARGS);
-int uopz_add_mock_interface_handler(UOPZ_OPCODE_HANDLER_ARGS);
-#endif
-
-typedef int (*uopz_opcode_handler_t) (UOPZ_OPCODE_HANDLER_ARGS);
-
-uopz_opcode_handler_t uopz_exit_handler;
-uopz_opcode_handler_t uopz_init_fcall_by_name_handler;
-uopz_opcode_handler_t uopz_init_fcall_handler;
-uopz_opcode_handler_t uopz_init_ns_fcall_by_name_handler;
-uopz_opcode_handler_t uopz_init_method_call_handler;
-uopz_opcode_handler_t uopz_init_static_method_call_handler;
-uopz_opcode_handler_t uopz_new_handler;
-uopz_opcode_handler_t uopz_fetch_constant_handler;
-uopz_opcode_handler_t uopz_do_fcall_handler;
-uopz_opcode_handler_t uopz_fetch_class_handler;
-uopz_opcode_handler_t uopz_add_trait_handler;
-uopz_opcode_handler_t uopz_add_interface_handler;
-#ifdef ZEND_FETCH_CLASS_CONSTANT
-uopz_opcode_handler_t uopz_fetch_class_constant_handler;
 #endif
 
 #define UOPZ_SET_HANDLER(h, o, n) do { \
@@ -89,51 +56,80 @@ uopz_opcode_handler_t uopz_fetch_class_constant_handler;
 	zend_set_user_opcode_handler(o, h); \
 } while (0)
 
-void uopz_handlers_init(void) {
-	UOPZ_SET_HANDLER(uopz_exit_handler,                     ZEND_EXIT,                      uopz_no_exit_handler);
-	UOPZ_SET_HANDLER(uopz_init_fcall_by_name_handler,		ZEND_INIT_FCALL_BY_NAME, 		uopz_call_handler);
-	UOPZ_SET_HANDLER(uopz_init_fcall_handler,				ZEND_INIT_FCALL, 				uopz_call_handler);
-	UOPZ_SET_HANDLER(uopz_init_ns_fcall_by_name_handler,	ZEND_INIT_NS_FCALL_BY_NAME, 	uopz_call_handler);
-	UOPZ_SET_HANDLER(uopz_init_method_call_handler,			ZEND_INIT_METHOD_CALL,			uopz_call_handler);
-	UOPZ_SET_HANDLER(uopz_init_static_method_call_handler,	ZEND_INIT_STATIC_METHOD_CALL,	uopz_call_handler);
-	UOPZ_SET_HANDLER(uopz_new_handler,						ZEND_NEW,						uopz_mock_handler);
-	UOPZ_SET_HANDLER(uopz_fetch_constant_handler,			ZEND_FETCH_CONSTANT,			uopz_constant_handler);
-	UOPZ_SET_HANDLER(uopz_do_fcall_handler,					ZEND_DO_FCALL,			uopz_return_handler);
-#ifdef ZEND_FETCH_CLASS_CONSTANT
-	UOPZ_SET_HANDLER(uopz_fetch_class_constant_handler,		ZEND_FETCH_CLASS_CONSTANT,		uopz_class_constant_handler);
-#endif
-	UOPZ_SET_HANDLER(uopz_fetch_class_handler,				ZEND_FETCH_CLASS,				uopz_fetch_handler);
-#if PHP_VERSION_ID < 70300
-	UOPZ_SET_HANDLER(uopz_add_trait_handler,				ZEND_ADD_TRAIT,					uopz_add_class_handler);
-	UOPZ_SET_HANDLER(uopz_add_interface_handler,			ZEND_ADD_INTERFACE,				uopz_add_class_handler);
+typedef int (*zend_vm_handler_t) (UOPZ_OPCODE_HANDLER_ARGS);
+
+zend_vm_handler_t zend_vm_exit;
+zend_vm_handler_t zend_vm_init_fcall;
+zend_vm_handler_t zend_vm_init_fcall_by_name;
+zend_vm_handler_t zend_vm_init_ns_fcall_by_name;
+zend_vm_handler_t zend_vm_init_method_call;
+zend_vm_handler_t zend_vm_init_static_method_call;
+zend_vm_handler_t zend_vm_new;
+zend_vm_handler_t zend_vm_fetch_constant;
+zend_vm_handler_t zend_vm_do_fcall;
+zend_vm_handler_t zend_vm_fetch_class;
+zend_vm_handler_t zend_vm_add_trait;
+zend_vm_handler_t zend_vm_add_interface;
+zend_vm_handler_t zend_vm_fetch_class_constant;
+
+int uopz_vm_exit(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_init_fcall(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_init_fcall_by_name(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_init_ns_fcall_by_name(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_init_static_method_call(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_new(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_fetch_constant(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_fetch_class(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_do_fcall(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_fetch_class_constant(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_add_trait(UOPZ_OPCODE_HANDLER_ARGS);
+int uopz_vm_add_interface(UOPZ_OPCODE_HANDLER_ARGS);
+
+static zend_always_inline zval* uopz_get_zval(const zend_op *opline, int op_type, const znode_op *node, const zend_execute_data *execute_data, zend_free_op *should_free, int type) {
+#if PHP_VERSION_ID >= 70300
+	return zend_get_zval_ptr(opline, op_type, node, execute_data, should_free, type);
 #else
-	UOPZ_SET_HANDLER(uopz_add_trait_handler,				ZEND_ADD_TRAIT,					uopz_add_mock_trait_handler);
-	UOPZ_SET_HANDLER(uopz_add_interface_handler,			ZEND_ADD_INTERFACE,				uopz_add_mock_interface_handler);
+	return zend_get_zval_ptr(op_type, node, execute_data, should_free, type);
 #endif
+}
+
+void uopz_handlers_init(void) {
+	UOPZ_SET_HANDLER(zend_vm_exit, ZEND_EXIT, uopz_vm_exit);
+	UOPZ_SET_HANDLER(zend_vm_init_fcall, ZEND_INIT_FCALL, uopz_vm_init_fcall);
+	UOPZ_SET_HANDLER(zend_vm_init_fcall_by_name, ZEND_INIT_FCALL_BY_NAME, uopz_vm_init_fcall_by_name);
+	UOPZ_SET_HANDLER(zend_vm_init_ns_fcall_by_name, ZEND_INIT_NS_FCALL_BY_NAME, uopz_vm_init_ns_fcall_by_name);
+	UOPZ_SET_HANDLER(zend_vm_init_method_call, ZEND_INIT_METHOD_CALL, uopz_vm_init_method_call);
+	UOPZ_SET_HANDLER(zend_vm_init_static_method_call, ZEND_INIT_STATIC_METHOD_CALL, uopz_vm_init_static_method_call);
+	UOPZ_SET_HANDLER(zend_vm_new, ZEND_NEW, uopz_vm_new);
+	UOPZ_SET_HANDLER(zend_vm_fetch_constant, ZEND_FETCH_CONSTANT, uopz_vm_fetch_constant);
+	UOPZ_SET_HANDLER(zend_vm_do_fcall, ZEND_DO_FCALL, uopz_vm_do_fcall);
+	UOPZ_SET_HANDLER(zend_vm_fetch_class_constant, ZEND_FETCH_CLASS_CONSTANT, uopz_vm_fetch_class_constant);
+	UOPZ_SET_HANDLER(zend_vm_fetch_class, ZEND_FETCH_CLASS, uopz_vm_fetch_class);
+	UOPZ_SET_HANDLER(zend_vm_add_trait, ZEND_ADD_TRAIT, uopz_vm_add_trait);
+	UOPZ_SET_HANDLER(zend_vm_add_interface, ZEND_ADD_INTERFACE, uopz_vm_add_interface);
 }
 
 void uopz_handlers_shutdown(void) {
-	UOPZ_UNSET_HANDLER(uopz_exit_handler,					ZEND_EXIT);
-	UOPZ_UNSET_HANDLER(uopz_init_fcall_by_name_handler,		ZEND_INIT_FCALL_BY_NAME);
-	UOPZ_UNSET_HANDLER(uopz_init_fcall_handler,				ZEND_INIT_FCALL);
-	UOPZ_UNSET_HANDLER(uopz_init_ns_fcall_by_name_handler,	ZEND_INIT_NS_FCALL_BY_NAME);
-	UOPZ_UNSET_HANDLER(uopz_init_method_call_handler,		ZEND_INIT_METHOD_CALL);
-	UOPZ_UNSET_HANDLER(uopz_init_static_method_call_handler,ZEND_INIT_STATIC_METHOD_CALL);
-	UOPZ_UNSET_HANDLER(uopz_new_handler,					ZEND_NEW);
-	UOPZ_UNSET_HANDLER(uopz_fetch_constant_handler,			ZEND_FETCH_CONSTANT);
-	UOPZ_UNSET_HANDLER(uopz_do_fcall_handler,				ZEND_DO_FCALL);
-#ifdef ZEND_FETCH_CLASS_CONSTANT
-	UOPZ_UNSET_HANDLER(uopz_fetch_class_constant_handler,	ZEND_FETCH_CLASS_CONSTANT);
-#endif
-	UOPZ_UNSET_HANDLER(uopz_fetch_class_handler,			ZEND_FETCH_CLASS);
-	UOPZ_UNSET_HANDLER(uopz_add_trait_handler,				ZEND_ADD_TRAIT);
-	UOPZ_UNSET_HANDLER(uopz_add_interface_handler,			ZEND_ADD_INTERFACE);
+	UOPZ_UNSET_HANDLER(zend_vm_exit,					ZEND_EXIT);
+	UOPZ_UNSET_HANDLER(zend_vm_init_fcall_by_name,		ZEND_INIT_FCALL_BY_NAME);
+	UOPZ_UNSET_HANDLER(zend_vm_init_fcall,				ZEND_INIT_FCALL);
+	UOPZ_UNSET_HANDLER(zend_vm_init_ns_fcall_by_name,	ZEND_INIT_NS_FCALL_BY_NAME);
+	UOPZ_UNSET_HANDLER(zend_vm_init_method_call,		ZEND_INIT_METHOD_CALL);
+	UOPZ_UNSET_HANDLER(zend_vm_init_static_method_call,ZEND_INIT_STATIC_METHOD_CALL);
+	UOPZ_UNSET_HANDLER(zend_vm_new,					ZEND_NEW);
+	UOPZ_UNSET_HANDLER(zend_vm_fetch_constant,			ZEND_FETCH_CONSTANT);
+	UOPZ_UNSET_HANDLER(zend_vm_do_fcall,				ZEND_DO_FCALL);
+	UOPZ_UNSET_HANDLER(zend_vm_fetch_class_constant,	ZEND_FETCH_CLASS_CONSTANT);
+	UOPZ_UNSET_HANDLER(zend_vm_fetch_class,			ZEND_FETCH_CLASS);
+	UOPZ_UNSET_HANDLER(zend_vm_add_trait,				ZEND_ADD_TRAIT);
+	UOPZ_UNSET_HANDLER(zend_vm_add_interface,			ZEND_ADD_INTERFACE);
 }
 
-int uopz_no_exit_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+int uopz_vm_exit(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
 	if (UOPZ(exit)) {
-		if (uopz_exit_handler)
-			return uopz_exit_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+		if (zend_vm_exit)
+			return zend_vm_exit(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
 
 		return ZEND_USER_OPCODE_DISPATCH;
 	}
@@ -169,260 +165,529 @@ int uopz_no_exit_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
 	}
 } /* }}} */
 
-int uopz_call_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-	switch (EX(opline)->opcode) {
-		case ZEND_INIT_FCALL_BY_NAME:
-		case ZEND_INIT_FCALL:
-		case ZEND_INIT_NS_FCALL_BY_NAME: {
-#if PHP_VERSION_ID >= 70300
-			CACHE_PTR(EX(opline)->result.num, NULL);
-#else
-			zval *function_name = EX_CONSTANT(EX(opline)->op2);
-			CACHE_PTR(Z_CACHE_SLOT_P(function_name), NULL);
-#endif
-		} break;
+int uopz_vm_init_fcall(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zval *name;
+	zend_function *fbc;
+	zend_execute_data *call;
+	zend_free_op free_op2;
 
-		case ZEND_INIT_METHOD_CALL: {
-			if (EX(opline)->op2_type == IS_CONST) {
-#if PHP_VERSION_ID >= 70300
-				CACHE_PTR(EX(opline)->result.num, NULL);
-				CACHE_PTR(EX(opline)->result.num + sizeof(void*), NULL);
-#else
-				zval *function_name = EX_CONSTANT(EX(opline)->op2);
-				CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), NULL, NULL);
-#endif
-			}
-		} break;
+	name = uopz_get_zval(
+		EX(opline),
+		EX(opline)->op2_type,
+		&EX(opline)->op2,
+		execute_data,
+		&free_op2, BP_VAR_R);
 
-		case ZEND_INIT_STATIC_METHOD_CALL: {
-			zend_class_entry *ce;
-			zval *mock;
-			zend_string *key = NULL;
-			
-			if (EX(opline)->op1_type == IS_CONST) {
-				key = zend_string_tolower(Z_STR_P(EX_CONSTANT(EX(opline)->op1)));
-			} else if (EX(opline)->op1_type != IS_UNUSED) 	{
-				ce = Z_CE_P(EX_VAR(EX(opline)->op1.var));
-				if (!ce) {
-					break;
-				}
-				key = zend_string_tolower(ce->name);
-			}
+	fbc = (zend_function*) zend_hash_find_ptr(EG(function_table), Z_STR_P(name));
 
-			if (key && (mock = zend_hash_find(&UOPZ(mocks), key))) {
-				zend_class_entry *poser;
-
-				if (Z_TYPE_P(mock) == IS_STRING) {
-					poser = zend_lookup_class(Z_STR_P(mock));
-					if (!poser) {
-						break;
-					}
-				} else poser = Z_OBJCE_P(mock);
-
-				if (EX(opline)->op1_type == IS_CONST) {
-#if PHP_VERSION_ID >= 70300
-					CACHE_PTR(EX(opline)->result.num, poser);
-#else
-					CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op1)), poser);
-#endif
-				} else {
-					Z_CE_P(EX_VAR(EX(opline)->op1.var)) = poser;
-				}
-			}
-
-			if (key && EX(opline)->op2_type == IS_CONST) {
-				zval *function_name = EX_CONSTANT(EX(opline)->op2);
-				if (EX(opline)->op1_type == IS_CONST) {
-#if PHP_VERSION_ID >= 70300
-					CACHE_PTR(EX(opline)->result.num + sizeof(void*), NULL);
-#else
-					CACHE_PTR(Z_CACHE_SLOT_P(function_name), NULL);
-#endif
-				} else {
-#if PHP_VERSION_ID >= 70300
-					CACHE_PTR(EX(opline)->result.num, NULL);
-					CACHE_PTR(EX(opline)->result.num + sizeof(void*), NULL);
-#else
-					CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), NULL, NULL);
-#endif
-				}
-			}
-			
-			if (key) {
-				zend_string_release(key);
-			}
-		} break;
+	if (!fbc) {
+		return ZEND_USER_OPCODE_DISPATCH;	
 	}
 
-	switch (EX(opline)->opcode) {
-		case ZEND_INIT_FCALL_BY_NAME:
-			if (uopz_init_fcall_by_name_handler)
-				return uopz_init_fcall_by_name_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		case ZEND_INIT_FCALL:
-			if (uopz_init_fcall_handler)
-				return uopz_init_fcall_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		case ZEND_INIT_NS_FCALL_BY_NAME:
-			if (uopz_init_ns_fcall_by_name_handler)
-				return uopz_init_ns_fcall_by_name_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		case ZEND_INIT_METHOD_CALL:
-			if (uopz_init_method_call_handler)
-				return uopz_init_method_call_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		case ZEND_INIT_STATIC_METHOD_CALL:
-			if (uopz_init_static_method_call_handler)
-				return uopz_init_static_method_call_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+	if (fbc->type == ZEND_USER_FUNCTION && !fbc->op_array.run_time_cache) {
+		/* TODO immutable for 7.3 */
+		fbc->op_array.run_time_cache = 
+			zend_arena_alloc(&CG(arena), fbc->op_array.cache_size);
+		memset(fbc->op_array.run_time_cache, 0, fbc->op_array.cache_size);
 	}
 
-	return ZEND_USER_OPCODE_DISPATCH;
+	call = zend_vm_stack_push_call_frame_ex(
+		EX(opline)->op1.num, 
+		ZEND_CALL_NESTED_FUNCTION, fbc, EX(opline)->extended_value, NULL, NULL);
+	call->prev_execute_data = EX(call);
+	EX(call) = call;
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
 } /* }}} */
 
-int uopz_constant_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-#if PHP_VERSION_ID >= 70300
-	CACHE_PTR(EX(opline)->extended_value, NULL);
-#elif PHP_VERSION_ID >= 70100
-	if (CACHED_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)))) {
-		CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)), NULL);
-	}
-#else
-	if (EX(opline)->op1_type == IS_UNUSED) {
-		if (CACHED_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)))) {
-			CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)), NULL);
-		}
-	} else {
-		zend_string *key = NULL;
-		zval *mock = NULL;
-		zend_class_entry *poser = NULL;
+int uopz_vm_init_fcall_by_name(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zval *name;
+	zend_function *fbc;
+	zend_execute_data *call;
+	zend_free_op free_op2;
 
-		if (EX(opline)->op1_type == IS_CONST) {
-			key = zend_string_tolower(Z_STR_P(EX_CONSTANT(EX(opline)->op1)));			
+	name = uopz_get_zval(
+		EX(opline),
+		EX(opline)->op2_type,
+		&EX(opline)->op2,
+		execute_data,
+		&free_op2, BP_VAR_R);
 
-			if ((mock = zend_hash_find(&UOPZ(mocks), key))) {
-				if (Z_TYPE_P(mock) == IS_OBJECT) {
-					poser = Z_OBJCE_P(mock);
-				} else poser = zend_lookup_class(Z_STR_P(mock));
-				CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op1)), poser);
-			}
+	fbc = (zend_function*) zend_hash_find_ptr(EG(function_table), Z_STR_P(name+1));
 
-			if (CACHED_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)))) {
-				CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)), NULL);
-			}
-
-			zend_string_release(key);		
-		} else {
-			key = zend_string_tolower(Z_CE_P(EX_VAR(EX(opline)->op1.var))->name);
-			
-			if ((mock = zend_hash_find(&UOPZ(mocks), key))) {
-				if (Z_TYPE_P(mock) == IS_OBJECT) {
-					poser = Z_OBJCE_P(mock);
-				} else poser = zend_lookup_class(Z_STR_P(mock));
-
-				Z_CE_P(EX_VAR(EX(opline)->op1.var)) = poser;
-			}
-
-			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)), 
-								  Z_CE_P(EX_VAR(EX(opline)->op1.var)), NULL);
-
-			zend_string_release(key);
-		}
-	}
-#endif
-
-	if (uopz_fetch_constant_handler) {
-		return uopz_fetch_constant_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+	if (!fbc) {
+		return ZEND_USER_OPCODE_DISPATCH;	
 	}
 
-	return ZEND_USER_OPCODE_DISPATCH;
+	if (fbc->type == ZEND_USER_FUNCTION && !fbc->op_array.run_time_cache) {
+		/* TODO immutable for 7.3 */
+		fbc->op_array.run_time_cache = 
+			zend_arena_alloc(&CG(arena), fbc->op_array.cache_size);
+		memset(fbc->op_array.run_time_cache, 0, fbc->op_array.cache_size);
+	}
+
+	call = zend_vm_stack_push_call_frame(
+		ZEND_CALL_NESTED_FUNCTION, 
+		fbc, EX(opline)->extended_value, NULL, NULL);
+	call->prev_execute_data = EX(call);
+	EX(call) = call;
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
 } /* }}} */
 
-int uopz_mock_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-	int UOPZ_VM_ACTION = ZEND_USER_OPCODE_DISPATCH;
-	zend_string *key;
-	zval *mock = NULL;
+int uopz_vm_init_ns_fcall_by_name(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zval *name;
+	zend_function *fbc;
+	zend_execute_data *call;
+	zend_free_op free_op2;
+
+	name = uopz_get_zval(
+		EX(opline),
+		EX(opline)->op2_type,
+		&EX(opline)->op2,
+		execute_data,
+		&free_op2, BP_VAR_R) + 1;
+
+	fbc = (zend_function*) zend_hash_find_ptr(EG(function_table), Z_STR_P(name));
+
+	if (!fbc) {
+		name++;
+		fbc = zend_hash_find_ptr(EG(function_table), Z_STR_P(name));
+		if (!fbc) {
+			zend_throw_error(NULL,
+				"Call to undefined function %s()",
+				Z_STRVAL_P(EX_CONSTANT(EX(opline)->op2)));
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+	}
+
+	if (fbc->type == ZEND_USER_FUNCTION && !fbc->op_array.run_time_cache) {
+		/* TODO immutable for 7.3 */
+		fbc->op_array.run_time_cache = 
+			zend_arena_alloc(&CG(arena), fbc->op_array.cache_size);
+		memset(fbc->op_array.run_time_cache, 0, fbc->op_array.cache_size);
+	}
+
+	call = zend_vm_stack_push_call_frame(
+		ZEND_CALL_NESTED_FUNCTION, 
+		fbc, EX(opline)->extended_value, NULL, NULL);
+	call->prev_execute_data = EX(call);
+	EX(call) = call;
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
+} /* }}} */
+
+int uopz_vm_init_static_method_call(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zend_string *clazz;
+	zend_object *object;
+	zval *method;
 	zend_class_entry *ce;
+	zend_function *fbc;
+	zend_execute_data *call;
+	zend_free_op free_op1;
+	zend_free_op free_op2;
 
 	if (EX(opline)->op1_type == IS_CONST) {
-#if PHP_VERSION_ID < 70300
-		ce = CACHED_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op1)));
-#else
-		ce = CACHED_PTR(EX(opline)->op2.num);
-#endif
+		if (uopz_find_mock(Z_STR_P(EX_CONSTANT(EX(opline)->op1)), &ce) != SUCCESS) {
+			if (zend_vm_init_static_method_call)
+				return zend_vm_init_static_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
 
-		if (UNEXPECTED(ce == NULL)) {
-			key = Z_STR_P(EX_CONSTANT(EX(opline)->op1));
-		} else {
-			key = ce->name;
+			return ZEND_USER_OPCODE_DISPATCH;
 		}
-
-		key = zend_string_tolower(key);
-	} else if(EX(opline)->op1_type == IS_UNUSED) {
+	} else if (EX(opline)->op1_type == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, EX(opline)->op1.num);
-		if (UNEXPECTED(ce == NULL)) {
-			return UOPZ_VM_ACTION;
+
+		if (uopz_find_mock(ce->name, &ce) != SUCCESS) {
+			if (zend_vm_init_static_method_call)
+				return zend_vm_init_static_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+			return ZEND_USER_OPCODE_DISPATCH;
 		}
-		key = 
-			zend_string_tolower(ce->name);
 	} else {
-		key = zend_string_tolower(
-			Z_CE_P(EX_VAR(EX(opline)->op1.var))->name);
-	}
+		ce = Z_CE_P(EX_VAR(EX(opline)->op1.var));
 
-	if (UNEXPECTED((mock = zend_hash_find(&UOPZ(mocks), key)))) {
-		switch (Z_TYPE_P(mock)) {
-			case IS_OBJECT:
-				ZVAL_COPY(
-					EX_VAR(EX(opline)->result.var), mock);
-#if PHP_VERSION_ID < 70100
-				EX(opline) = 
-					OP_JMP_ADDR(EX(opline), EX(opline)->op2);
-#else
-				if (EX(opline)->extended_value == 0 && 
-					(EX(opline)+1)->opcode == ZEND_DO_FCALL) {
-					EX(opline) += 2;
-				} else if ((EX(opline)+1)->extended_value == 0 && (EX(opline)+1)->opcode == ZEND_SEND_VAL_EX) {
-					// avoid infinite loop if the mock has a no-args constructor but the constructor receives args
-					int args_ctr = 1;
+		if (uopz_find_mock(ce->name, &ce) != SUCCESS) {
+			if (zend_vm_init_static_method_call)
+				return zend_vm_init_static_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
 
-					while ((EX(opline)+args_ctr)->opcode == ZEND_SEND_VAL_EX) {
-						args_ctr++;
-					}
-
-					EX(opline) += args_ctr + 1;
-				}
-#endif
-				UOPZ_VM_ACTION = ZEND_USER_OPCODE_CONTINUE;
-			break;
-
-			case IS_STRING:
-				ce = zend_lookup_class(Z_STR_P(mock));
-				if (EXPECTED(ce)) {
-					if (EX(opline)->op1_type == IS_CONST) {
-#if PHP_VERSION_ID < 70300
-						CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op1)), ce);
-#else
-						CACHE_PTR(EX(opline)->op2.num, ce);
-#endif
-					} else if (EX(opline)->op1_type != IS_UNUSED) {
-						Z_CE_P(EX_VAR(EX(opline)->op1.var)) = ce;
-					} else {
-						/* oh dear, can't do what is requested */			
-					}
-					
-				}
-			break;
+			return ZEND_USER_OPCODE_DISPATCH;
 		}
 	}
 
-	zend_string_release(key);
+	if (EX(opline)->op2_type != IS_UNUSED) {
+		method = uopz_get_zval(
+			EX(opline),
+			EX(opline)->op2_type,
+			&EX(opline)->op2,
+			execute_data,
+			&free_op2, BP_VAR_R);
 
-	if (UOPZ_VM_ACTION == ZEND_USER_OPCODE_DISPATCH) {
-		if (uopz_new_handler) {
-			return uopz_new_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+		if (EX(opline)->op2_type != IS_CONST) {
+			if (Z_TYPE_P(method) != IS_STRING) {
+				do {
+					if (EX(opline)->op2_type & (IS_VAR|IS_CV) && Z_ISREF_P(method)) {
+						method = Z_REFVAL_P(method);
+
+						if (Z_TYPE_P(method) == IS_STRING) {
+							break;
+						}
+					}
+
+					if (zend_vm_init_static_method_call)
+						return zend_vm_init_static_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+					return ZEND_USER_OPCODE_DISPATCH;
+				} while (0);
+			}
+		}
+
+		if (ce->get_static_method) {
+			fbc = ce->get_static_method(ce, Z_STR_P(method));
+		} else {
+			fbc = zend_std_get_static_method(ce, 
+				Z_STR_P(method), 
+				((EX(opline)->op2_type == IS_CONST) ? 
+					(EX_CONSTANT(EX(opline)->op2) + 1) : NULL));
+		}
+
+		if (fbc == NULL) {
+			if (zend_vm_init_static_method_call)
+				return zend_vm_init_static_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+			return ZEND_USER_OPCODE_DISPATCH;
+		}
+
+		if (fbc->type == ZEND_USER_FUNCTION && !fbc->op_array.run_time_cache) {
+			fbc->op_array.run_time_cache = 
+				zend_arena_alloc(&CG(arena), fbc->op_array.cache_size);
+			memset(fbc->op_array.run_time_cache, 0, fbc->op_array.cache_size);
+		}
+
+		if (EX(opline)->op2_type != IS_CONST) {
+			if (free_op2) {
+				zval_ptr_dtor(free_op2);
+			}
+		}
+	} else {
+		if (ce->constructor == NULL) {
+			zend_throw_error(NULL, 
+				"Cannot call constructor");
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+
+		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+			zend_throw_error(NULL, 
+				"Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+
+		fbc = ce->constructor;
+
+		if (fbc->type == ZEND_USER_FUNCTION && !fbc->op_array.run_time_cache) {
+			fbc->op_array.run_time_cache = 
+				zend_arena_alloc(&CG(arena), fbc->op_array.cache_size);
+			memset(fbc->op_array.run_time_cache, 0, fbc->op_array.cache_size);
 		}
 	}
 
-	return UOPZ_VM_ACTION;
+	object = NULL;
+	
+	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
+		if (Z_TYPE(EX(This)) == IS_OBJECT && instanceof_function(Z_OBJCE(EX(This)), ce)) {
+			object = Z_OBJ(EX(This));
+			ce = object->ce;
+		} else {
+			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
+				zend_error(
+					E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
+			} else {
+				zend_throw_error(
+					zend_ce_error,
+					"Non-static method %s::%s() cannot be called statically",
+					ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
+			}
+
+			if (EG(exception)) {
+				return ZEND_USER_OPCODE_CONTINUE;
+			}
+		}
+	}
+
+	if (EX(opline)->op1_type == IS_UNUSED) {
+		if ((EX(opline)->op1.num & ZEND_FETCH_CLASS_MASK) == ZEND_FETCH_CLASS_PARENT ||
+		    (EX(opline)->op1.num & ZEND_FETCH_CLASS_MASK) == ZEND_FETCH_CLASS_SELF) {
+			if (Z_TYPE(EX(This)) == IS_OBJECT) {
+				ce = Z_OBJCE(EX(This));
+			} else {
+				ce = Z_CE(EX(This));
+			}
+			/* find mock and method */
+		}
+	}
+
+	call = zend_vm_stack_push_call_frame(
+		ZEND_CALL_NESTED_FUNCTION, 
+		fbc, EX(opline)->extended_value, ce, object);
+
+	call->prev_execute_data = EX(call);
+	EX(call) = call;
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
 } /* }}} */
 
-static inline void uopz_run_hook(zend_function *function, zend_execute_data *execute_data) { /* {{{ */
+int uopz_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zval *object;
+	zend_object *obj, *oobj;
+	zend_function *fbc;
+	zend_class_entry *scope;
+	zend_execute_data *call;
+	zval *method;
+	zend_class_entry *mock;
+	uint32_t info;
+	zend_free_op free_op1;
+	zend_free_op free_op2;
+
+	object = uopz_get_zval(
+			EX(opline),
+			EX(opline)->op1_type,
+			&EX(opline)->op1,
+			execute_data,
+			&free_op1, BP_VAR_R);
+
+	if (!object || Z_TYPE_P(object) == IS_UNDEF) {
+		if (zend_vm_init_method_call)
+			return zend_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+		return ZEND_USER_OPCODE_DISPATCH;
+	}
+
+	method = uopz_get_zval(
+			EX(opline),
+			EX(opline)->op2_type,
+			&EX(opline)->op2,
+			execute_data,
+			&free_op2, BP_VAR_R);
+
+	if (!method) {
+		if (zend_vm_init_method_call)
+			return zend_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+		return ZEND_USER_OPCODE_DISPATCH;
+	}
+
+	if (Z_TYPE_P(method) != IS_STRING) {
+		do {
+			if ((EX(opline)->op2_type & (IS_VAR|IS_CV)) && Z_ISREF_P(method)) {
+				method = Z_REFVAL_P(method);
+
+				if (Z_TYPE_P(method) == IS_STRING) {
+					break;
+				}
+			}
+			
+			if (zend_vm_init_method_call)
+				return zend_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+			return ZEND_USER_OPCODE_DISPATCH;
+		} while(0);
+	}
+
+	if (EX(opline)->op1_type != IS_UNUSED && Z_TYPE_P(object) != IS_OBJECT) {
+		do {
+			if (EX(opline)->op1_type == IS_CONST || Z_TYPE_P(object) != IS_OBJECT) {
+				if ((EX(opline)->op1_type & (IS_VAR|IS_CV)) && Z_ISREF_P(object)) {
+					object = Z_REFVAL_P(object);
+
+					if (Z_TYPE_P(object) == IS_OBJECT) {
+						break;
+					}
+				
+				}
+			}
+
+			if (zend_vm_init_method_call)
+				return zend_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+			return ZEND_USER_OPCODE_DISPATCH;
+		} while (0);
+	}
+
+	oobj = obj = Z_OBJ_P(object);
+	scope = obj->ce;
+
+	if (obj->handlers->get_method == NULL) {
+		if (zend_vm_init_method_call)
+			return zend_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+		return ZEND_USER_OPCODE_DISPATCH;
+	}
+
+	fbc = obj->handlers->get_method(&obj, 
+			Z_STR_P(method), 
+			((EX(opline)->op2_type == IS_CONST) ? 
+				(EX_CONSTANT(EX(opline)->op2) + 1) : NULL));
+
+	if (!fbc) {
+		if (zend_vm_init_method_call)
+			return zend_vm_init_method_call(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+
+		return ZEND_USER_OPCODE_DISPATCH;
+	}
+
+	if (EX(opline)->op2_type != IS_CONST) {
+		if (free_op2) {
+			zval_ptr_dtor(free_op2);
+		}
+	}
+
+	if (uopz_find_mock(scope->name, &mock) == SUCCESS) {
+		uopz_find_method(
+			mock, Z_STR_P(method), &fbc);
+	}
+
+	info = ZEND_CALL_NESTED_FUNCTION;
+
+	if ((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+		obj = NULL;
+#if PHP_VERSION_ID >= 70300
+		if (free_op1) {
+			zval_ptr_dtor(free_op1);
+		}
+
+		if ((EX(opline)->op1_type & (IS_VAR|IS_TMP_VAR)) && EG(exception)) {
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+#endif
+	} else if (EX(opline)->op1_type & (IS_VAR|IS_TMP_VAR|IS_CV)) {
+		info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_RELEASE_THIS;
+
+#if PHP_VERSION_ID >= 70300
+		if (EX(opline)->op1_type == IS_CV) {
+			GC_ADDREF(Z_OBJ_P(object));
+		} else if (free_op1 != object) {
+			GC_ADDREF(Z_OBJ_P(object));
+			zval_ptr_dtor(free_op1);
+		}
+#else
+		GC_ADDREF(Z_OBJ_P(object));
+#endif
+	}
+
+#if PHP_VERSION_ID < 70300
+	if (free_op1) {
+		zval_ptr_dtor(free_op1);
+	}
+
+	if (free_op2) {
+		zval_ptr_dtor(free_op2);
+	}
+
+	if ((EX(opline)->op1_type & (IS_VAR|IS_TMP_VAR)) && EG(exception)) {
+		return ZEND_USER_OPCODE_CONTINUE;
+	}
+#endif
+
+	if (fbc->type == ZEND_USER_FUNCTION && !fbc->op_array.run_time_cache) {
+		fbc->op_array.run_time_cache = 
+			zend_arena_alloc(&CG(arena), fbc->op_array.cache_size);
+		memset(fbc->op_array.run_time_cache, 0, fbc->op_array.cache_size);
+	}
+
+	call = zend_vm_stack_push_call_frame(info, 
+		fbc, EX(opline)->extended_value, scope, obj);
+
+	call->prev_execute_data = EX(call);
+	EX(call) = call;
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
+} /* }}} */
+
+int uopz_vm_new(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zval *result;
+	zend_function *constructor;
+	zend_class_entry *ce;
+	zend_execute_data *call;
+
+	if (EX(opline)->op1_type == IS_CONST) {
+		if (uopz_find_mock(Z_STR_P(EX_CONSTANT(EX(opline)->op1)), &ce) != SUCCESS) {
+			ce = zend_fetch_class_by_name(
+				Z_STR_P(EX_CONSTANT(EX(opline)->op1)), 
+				EX_CONSTANT(EX(opline)->op1) + 1, 
+				ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
+
+			if (ce == NULL) {
+				ZVAL_UNDEF(EX_VAR(EX(opline)->result.var));
+
+				return ZEND_USER_OPCODE_DISPATCH;
+			}
+		}
+	} else if (EX(opline)->op1_type == IS_UNUSED) {
+		ce = zend_fetch_class(
+			NULL, EX(opline)->op1.num);
+		uopz_find_mock(ce->name, &ce);	
+	} else {
+		ce = Z_CE_P(
+			EX_VAR(EX(opline)->op1.var));
+		uopz_find_mock(ce->name, &ce);
+	}
+
+	result = EX_VAR(EX(opline)->result.var);
+
+	if (object_init_ex(result, ce) != SUCCESS) {
+		ZVAL_UNDEF(result);
+
+		return ZEND_USER_OPCODE_CONTINUE;
+	}
+
+	constructor = Z_OBJ_HT_P(result)->get_constructor(Z_OBJ_P(result));
+
+	if (!constructor) {
+		if (EG(exception)) {
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+
+		if (EX(opline)->extended_value == 0 && (EX(opline)+1)->opcode == ZEND_DO_FCALL) {
+			EX(opline) = EX(opline) + 2;
+
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+
+		call = zend_vm_stack_push_call_frame(
+			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
+			EX(opline)->extended_value, NULL, NULL);
+	} else {
+		if (constructor->type == ZEND_USER_FUNCTION && !constructor->op_array.run_time_cache) {
+			constructor->op_array.run_time_cache = 
+				zend_arena_alloc(&CG(arena), constructor->op_array.cache_size);
+			memset(constructor->op_array.run_time_cache, 0, constructor->op_array.cache_size);
+		}
+
+		call = zend_vm_stack_push_call_frame(
+			ZEND_CALL_FUNCTION | ZEND_CALL_RELEASE_THIS | ZEND_CALL_CTOR,
+			constructor,
+			EX(opline)->extended_value,
+			ce,
+			Z_OBJ_P(result));
+
+		Z_ADDREF_P(result);
+	}
+
+	call->prev_execute_data = EX(call);
+	EX(call) = call;
+
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
+} /* }}} */
+
+static zend_always_inline void uopz_run_hook(zend_function *function, zend_execute_data *execute_data) { /* {{{ */
 	uopz_hook_t *uhook = uopz_find_hook(function);
 
 	if (uhook && !uhook->busy) {
@@ -431,7 +696,7 @@ static inline void uopz_run_hook(zend_function *function, zend_execute_data *exe
 } /* }}} */
 
 /* {{{ */
-static inline int php_uopz_leave_helper(zend_execute_data *execute_data) {
+static zend_always_inline int php_uopz_leave_helper(zend_execute_data *execute_data) {
 	zend_execute_data *call = EX(call);
 
 	EX(call) = call->prev_execute_data;
@@ -442,7 +707,7 @@ static inline int php_uopz_leave_helper(zend_execute_data *execute_data) {
 	return ZEND_USER_OPCODE_LEAVE;
 } /* }}} */
 
-int uopz_return_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+int uopz_vm_do_fcall(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
 	zend_execute_data *call = EX(call);
 
 	if (call) {
@@ -459,7 +724,7 @@ int uopz_return_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
 
 			if (UOPZ_RETURN_IS_EXECUTABLE(ureturn)) {
 				if (UOPZ_RETURN_IS_BUSY(ureturn)) {
-					goto _uopz_return_handler_dispatch;
+					goto _uopz_vm_do_fcall_dispatch;
 				}
 
 				uopz_execute_return(ureturn, call, return_value);
@@ -479,228 +744,228 @@ int uopz_return_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
 		}
 	}
 
-_uopz_return_handler_dispatch:
-	if (uopz_do_fcall_handler) {
-		return uopz_do_fcall_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
+_uopz_vm_do_fcall_dispatch:
+	if (zend_vm_do_fcall) {
+		return zend_vm_do_fcall(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
 	}
 
 	return ZEND_USER_OPCODE_DISPATCH;
 } /* }}} */
 
-#ifdef ZEND_FETCH_CLASS_CONSTANT
-int uopz_class_constant_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-	if (EX(opline)->op1_type == IS_CONST) {
-		zval *name = EX_CONSTANT(EX(opline)->op1);
-		zend_string *key = Z_STR_P(name);
-		zval *mock = NULL;
-		zend_class_entry *poser = NULL;
-
-		key = zend_string_tolower(key);
-		
-		if ((mock = zend_hash_find(&UOPZ(mocks), key))) {
-			if (Z_TYPE_P(mock) == IS_OBJECT) {
-				poser = Z_OBJCE_P(mock);
-			} else poser = zend_lookup_class(Z_STR_P(mock));
-
-			if (poser) {
-#if PHP_VERSION_ID < 70300
-				CACHE_PTR(Z_CACHE_SLOT_P(name), poser);
-#else
-				CACHE_PTR(EX(opline)->extended_value, poser);
-#endif
-			}
-		}
-
-		zend_string_release(key);
-	}
-
-#if PHP_VERSION_ID < 70300
-	CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)), NULL);
-#else
-	CACHE_PTR(EX(opline)->extended_value + sizeof(void*), NULL);
-	if (EX(opline)->op1_type != IS_CONST) {
-		CACHE_PTR(EX(opline)->extended_value, NULL);
-	}
-#endif
-
-	if (uopz_fetch_class_constant_handler) {
-		return uopz_fetch_class_constant_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-	}
-	
-	return ZEND_USER_OPCODE_DISPATCH;
-} /* }}} */
-#endif
-
-int uopz_fetch_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-	zval *name = NULL;
-	zend_string *key = NULL;
-	int UOPZ_VM_ACTION = ZEND_USER_OPCODE_DISPATCH;
-
-	do {
-		if (EX(opline)->op2_type == IS_UNUSED) {
-			break;
-		}
-		
-		if (EX(opline)->op2_type == IS_CONST) {
-			name = 
-				EX_CONSTANT(EX(opline)->op2);
-			if (name) {
-				key = Z_STR_P(name);
-			}			
-		} else if (EX(opline)->op2_type != IS_UNUSED) {
-			name = EX_VAR(EX(opline)->op2.var);
-			if (Z_TYPE_P(name) == IS_STRING) {
-				key = Z_STR_P(name);
-			} else if (Z_TYPE_P(name) == IS_OBJECT) {
-				key = Z_OBJCE_P(name)->name;
-			} else {
-				
-			}
-		}
-
-		if (key) {
-			zval *mock = NULL;
-			zend_class_entry *ce = NULL;
-			zend_string *lookup = zend_string_tolower(key);
-
-			if (UNEXPECTED((mock = zend_hash_find(&UOPZ(mocks), lookup)))) {
-
-				switch (Z_TYPE_P(mock)) {
-					case IS_OBJECT: ce = Z_OBJCE_P(mock); break;
-					case IS_STRING: ce = zend_lookup_class(Z_STR_P(mock)); break;
-				}
-
-				if (ce) {
-					if (EX(opline)->op2_type == IS_CONST) {
-#if PHP_VERSION_ID < 70300
-						CACHE_PTR(Z_CACHE_SLOT_P(name), ce);
-#else
-						CACHE_PTR(EX(opline)->result.num, ce);
-#endif
-					}
-
-					Z_CE_P(EX_VAR(EX(opline)->result.var)) = ce;
-					UOPZ_VM_ACTION = ZEND_USER_OPCODE_CONTINUE;
-				}
-			}
-
-			zend_string_release(lookup);
-		}
-	} while(0);
-
-	if (UOPZ_VM_ACTION == ZEND_USER_OPCODE_CONTINUE) {
-		EX(opline) = EX(opline) + 1;
-	} else {
-		if (uopz_fetch_class_handler) {
-			return uopz_fetch_class_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		}
-	}
-
-	return UOPZ_VM_ACTION;
-} /* }}} */
-
+int uopz_vm_fetch_constant(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
 #if PHP_VERSION_ID >= 70300
-int uopz_add_mock_interface_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-	zend_class_entry *ce = Z_CE_P(EX_VAR(EX(opline)->op1.var));
-	zval *name           = EX_CONSTANT(EX(opline)->op2);
-	zend_string *key     = zend_string_tolower(Z_STR_P(name));
-	zval *mock = NULL;
-	int UOPZ_VM_ACTION   = ZEND_USER_OPCODE_DISPATCH;
-
-	if ((mock = zend_hash_find(&UOPZ(mocks), key))) {
-		if (Z_TYPE_P(mock) == IS_STRING) {
-			zend_class_entry *iface = zend_lookup_class(Z_STR_P(mock));
-			
-			if (iface) {
-				zend_do_implement_interface(ce, iface);
-			}
-		} else {
-			zend_do_implement_interface(ce, Z_OBJCE_P(mock));
-		}
-		UOPZ_VM_ACTION = ZEND_USER_OPCODE_CONTINUE;
+	CACHE_PTR(EX(opline)->extended_value, NULL);
+#else
+	if (CACHED_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)))) {
+		CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(EX(opline)->op2)), NULL);
 	}
-	
-	zend_string_release(key);
-
-	if (UOPZ_VM_ACTION == ZEND_USER_OPCODE_CONTINUE) {
-		EX(opline) = EX(opline) + 1;
-	} else {
-		if (uopz_add_interface_handler) {
-			return uopz_add_interface_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		}
-	}
-
-	return UOPZ_VM_ACTION;
-} /* }}} */
-
-int uopz_add_mock_trait_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-	zend_class_entry *ce = Z_CE_P(EX_VAR(EX(opline)->op1.var));
-	zval *name           = EX_CONSTANT(EX(opline)->op2);
-	zend_string *key     = zend_string_tolower(Z_STR_P(name));
-	zval *mock = NULL;
-	int UOPZ_VM_ACTION   = ZEND_USER_OPCODE_DISPATCH;
-
-	if ((mock = zend_hash_find(&UOPZ(mocks), key))) {
-		if (Z_TYPE_P(mock) == IS_STRING) {
-			zend_class_entry *trait = zend_lookup_class(Z_STR_P(mock));
-			
-			if (trait) {
-				zend_do_implement_trait(ce, trait);
-			}
-		} else {
-			zend_do_implement_trait(ce, Z_OBJCE_P(mock));
-		}
-		UOPZ_VM_ACTION = ZEND_USER_OPCODE_CONTINUE;
-	}
-	
-	zend_string_release(key);
-
-	if (UOPZ_VM_ACTION == ZEND_USER_OPCODE_CONTINUE) {
-		EX(opline) = EX(opline) + 1;
-	} else {
-		if (uopz_add_trait_handler) {
-			return uopz_add_trait_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		}
-	}
-
-	return UOPZ_VM_ACTION;
-} /* }}} */
 #endif
 
-int uopz_add_class_handler(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
-	zval *name = EX_CONSTANT(EX(opline)->op2);
-	zend_string *key = zend_string_tolower(Z_STR_P(name));
-	zval *mock = NULL;
-	
-	if ((mock = zend_hash_find(&UOPZ(mocks), key))) {
-		if (Z_TYPE_P(mock) == IS_STRING) {
-			zend_class_entry *ce = zend_lookup_class(Z_STR_P(mock));
-			
-			if (ce) {
-#if PHP_VERSION_ID < 70300
-				CACHE_PTR(Z_CACHE_SLOT_P(name), ce);
-#endif
-			}
-		} else {
-#if PHP_VERSION_ID < 70300
-			CACHE_PTR(Z_CACHE_SLOT_P(name), Z_OBJCE_P(mock));
-#endif
-		}
+	if (zend_vm_fetch_constant) {
+		return zend_vm_fetch_constant(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
 	}
-	
-	zend_string_release(key);	
 
-	if (uopz_add_trait_handler || uopz_add_interface_handler) {
-		switch (EX(opline)->opcode) {
-			case ZEND_ADD_INTERFACE:
-				return uopz_add_interface_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-
-			case ZEND_ADD_TRAIT:
-				return uopz_add_trait_handler(UOPZ_OPCODE_HANDLER_ARGS_PASSTHRU);
-		}
-	}
-	
 	return ZEND_USER_OPCODE_DISPATCH;
+} /* }}} */
+
+int uopz_vm_fetch_class_constant(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zend_class_entry *ce, *scope;
+	zend_class_constant *c;
+	zval *value;
+
+	if (EX(opline)->op1_type == IS_CONST) {
+		if (uopz_find_mock(Z_STR_P(EX_CONSTANT(EX(opline)->op1)), &ce) != SUCCESS) {
+			ce = zend_fetch_class_by_name(
+				Z_STR_P(EX_CONSTANT(EX(opline)->op1)), 
+				EX_CONSTANT(EX(opline)->op1) + 1, 
+				ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
+
+			if (!ce) {
+				ZVAL_UNDEF(EX_VAR(EX(opline)->result.var));
+
+				return ZEND_USER_OPCODE_CONTINUE;
+			}
+		}
+	} else {
+		if (EX(opline)->op1_type == IS_UNUSED) {
+			ce = zend_fetch_class(NULL, EX(opline)->op1.num);
+			if (!ce) {
+				ZVAL_UNDEF(EX_VAR(EX(opline)->result.var));
+
+				return ZEND_USER_OPCODE_CONTINUE;
+			}
+			uopz_find_mock(ce->name, &ce);
+		} else {
+			ce = 
+				Z_CE_P(EX_VAR(EX(opline)->op1.var));
+			uopz_find_mock(ce->name, &ce);
+		}
+	}
+
+	if ((c = zend_hash_find_ptr(&ce->constants_table, Z_STR_P(EX_CONSTANT(EX(opline)->op2))))) {
+		scope = EX(func)->op_array.scope;
+		if (!zend_verify_const_access(c, scope)) {
+			zend_throw_error(NULL, 
+				"Cannot access const %s::%s", 
+				ZSTR_VAL(ce->name), Z_STRVAL_P(EX_CONSTANT(EX(opline)->op2)));
+			ZVAL_UNDEF(EX_VAR(EX(opline)->result.var));
+
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+
+		value = &c->value;
+		if (Z_CONSTANT_P(value)) {
+			zval_update_constant_ex(value, c->ce);
+			if (EG(exception)) {
+				ZVAL_UNDEF(EX_VAR(EX(opline)->result.var));
+
+				return ZEND_USER_OPCODE_CONTINUE;
+			}
+		}
+	} else {
+		zend_throw_error(NULL, 
+			"Undefined class constant '%s'", 
+			Z_STRVAL_P(EX_CONSTANT(EX(opline)->op2)));
+		ZVAL_UNDEF(EX_VAR(EX(opline)->result.var));
+
+		return ZEND_USER_OPCODE_CONTINUE;
+	}
+
+#ifdef ZTS
+	if (ce->type == ZEND_INTERNAL_CLASS) {
+		ZVAL_DUP(EX_VAR(EX(opline)->result.var), value);
+	} else {
+		ZVAL_COPY(EX_VAR(EX(opline)->result.var), value);
+	}
+#else
+	ZVAL_COPY(EX_VAR(EX(opline)->result.var), value);
+#endif
+
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
+} /* }}} */
+
+int uopz_vm_fetch_class(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zval *name;
+	zend_free_op free_op2;
+	
+	if (EX(opline)->op2_type == IS_UNUSED) {
+		Z_CE_P(EX_VAR(EX(opline)->result.var)) = 
+			zend_fetch_class(NULL, EX(opline)->op1.num);
+		
+		if (!EG(exception)) {
+			uopz_find_mock(
+				Z_CE_P(EX_VAR(EX(opline)->result.var))->name, 
+				&Z_CE_P(EX_VAR(EX(opline)->result.var)));
+		}
+
+		EX(opline) = EX(opline) + 1;
+		return ZEND_USER_OPCODE_CONTINUE;
+	} else if (EX(opline)->op2_type == IS_CONST) {
+		name = uopz_get_zval(
+			EX(opline),
+			EX(opline)->op2_type,
+			&EX(opline)->op2,
+			execute_data,
+			&free_op2, BP_VAR_R);
+
+		if (uopz_find_mock(Z_STR_P(name), &Z_CE_P(EX_VAR(EX(opline)->result.var))) != SUCCESS) {
+			Z_CE_P(EX_VAR(EX(opline)->result.var)) = zend_fetch_class_by_name(
+									Z_STR_P(name), 
+									name + 1, 
+									EX(opline)->op1.num);
+		}
+	} else {
+		name = uopz_get_zval(
+			EX(opline),
+			EX(opline)->op2_type,
+			&EX(opline)->op2,
+			execute_data,
+			&free_op2, BP_VAR_R);
+_uopz_vm_fetch_class_try:
+		if (Z_TYPE_P(name) == IS_OBJECT) {
+			if (uopz_find_mock(Z_OBJCE_P(name)->name, &Z_CE_P(EX_VAR(EX(opline)->result.var))) != SUCCESS) {
+				Z_CE_P(EX_VAR(EX(opline)->result.var)) = Z_OBJCE_P(name);	
+			}
+		} else if (Z_TYPE_P(name) == IS_STRING) {
+			if (uopz_find_mock(Z_STR_P(name), &Z_CE_P(EX_VAR(EX(opline)->result.var))) != SUCCESS) {
+				Z_CE_P(EX_VAR(EX(opline)->result.var)) = zend_fetch_class(Z_STR_P(name), EX(opline)->op1.num);
+			}
+		} else if (EX(opline)->op2_type & (IS_VAR|IS_CV) && Z_TYPE_P(name) == IS_REFERENCE) {
+			name = Z_REFVAL_P(name);
+			goto _uopz_vm_fetch_class_try;
+		} else {
+			if (EX(opline)->op2_type == IS_CV && Z_TYPE_P(name) == IS_UNDEF) {
+				if (EG(exception)) {
+					return ZEND_USER_OPCODE_CONTINUE;
+				}
+			}
+			zend_throw_error(NULL, "Class name must be a valid object or a string");
+		}
+	}
+
+	if (free_op2) {
+		zval_ptr_dtor(free_op2);
+	}
+
+	EX(opline) = EX(opline) + 1;
+	
+	return ZEND_USER_OPCODE_CONTINUE;
+} /* }}} */
+
+int uopz_vm_add_trait(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zend_class_entry *ce = Z_CE_P(EX_VAR(EX(opline)->op1.var)), 
+                         *trait;
+	zval *name = EX_CONSTANT(EX(opline)->op2);
+
+	if (uopz_find_mock(Z_STR_P(name), &trait) != SUCCESS) {
+		trait = zend_fetch_class_by_name(
+				Z_STR_P(name), 
+				name + 1, 
+				ZEND_FETCH_CLASS_TRAIT);
+
+		if (!trait) {
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+	}
+
+	if (!(trait->ce_flags & ZEND_ACC_TRAIT)) {
+		zend_error_noreturn(E_ERROR, "%s cannot use %s - it is not a trait", ZSTR_VAL(ce->name), ZSTR_VAL(trait->name));
+	}
+
+	zend_do_implement_trait(ce, trait);
+
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
+} /* }}} */
+
+int uopz_vm_add_interface(UOPZ_OPCODE_HANDLER_ARGS) { /* {{{ */
+	zend_class_entry *ce = Z_CE_P(EX_VAR(EX(opline)->op1.var)), 
+                         *iface;
+	zval *name = EX_CONSTANT(EX(opline)->op2);
+
+	if (uopz_find_mock(Z_STR_P(name), &iface) != SUCCESS) {
+		iface = zend_fetch_class_by_name(
+				Z_STR_P(name), 
+				name + 1, 
+				ZEND_FETCH_CLASS_TRAIT);
+
+		if (!iface) {
+			return ZEND_USER_OPCODE_CONTINUE;
+		}
+	}
+
+	if (!(iface->ce_flags & ZEND_ACC_INTERFACE)) {
+		zend_error_noreturn(E_ERROR, "%s cannot implement %s - it is not an interface", ZSTR_VAL(ce->name), ZSTR_VAL(iface->name));
+	}
+
+	zend_do_implement_interface(ce, iface);
+
+	EX(opline) = EX(opline) + 1;
+
+	return ZEND_USER_OPCODE_CONTINUE;
 } /* }}} */
 
 #endif	/* UOPZ_HANDLERS_H */

--- a/src/hook.c
+++ b/src/hook.c
@@ -171,6 +171,10 @@ void uopz_execute_hook(uopz_hook_t *uhook, zend_execute_data *execute_data) { /*
 		}
 	}
 
+	if (EG(exception)) {
+		EG(current_execute_data)->opline = EG(opline_before_exception);
+	}
+
 _exit_uopz_execute_hook:
 	zval_ptr_dtor(&closure);
 

--- a/src/return.c
+++ b/src/return.c
@@ -195,6 +195,10 @@ void uopz_execute_return(uopz_return_t *ureturn, zend_execute_data *execute_data
 		}
 	}
 
+	if (EG(exception)) {
+		EG(current_execute_data)->opline = EG(opline_before_exception);
+	}
+
 _exit_uopz_execute_return:
 	zval_ptr_dtor(&closure);
 

--- a/tests/004.phpt
+++ b/tests/004.phpt
@@ -74,12 +74,12 @@ int(5)
 int(10)
 object(Bar)#1 (0) {
 }
-object(Qux)#1 (0) {
+object(Qux)#2 (0) {
 }
 int(50)
 int(50)
 int(20)
-object(Interfacing)#2 (0) {
+object(Interfacing)#3 (0) {
 }
-object(Traiting)#2 (0) {
+object(Traiting)#3 (0) {
 }

--- a/tests/012.phpt
+++ b/tests/012.phpt
@@ -57,7 +57,7 @@ var_dump($foo->method());
 var_dump(Foo::staticFunction());
 
 try {
-	var_dump($foo->priv());
+	var_dump($foo->priv(false));
 } catch(Error $e) {
 	var_dump($e->getMessage());	
 }

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -1,0 +1,29 @@
+--TEST--
+init method call
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public function method() {
+		return false;
+	}
+}
+
+class Bar {
+	public function method() {
+		return true;
+	}
+}
+
+$foo = new Foo();
+
+var_dump($foo->method());
+
+uopz_set_mock(Foo::class, Bar::class);
+
+var_dump($foo->method());
+?>
+--EXPECTF--
+bool(false)
+bool(true)

--- a/tests/023.phpt
+++ b/tests/023.phpt
@@ -1,0 +1,27 @@
+--TEST--
+init static method call
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public static function method() {
+		return false;
+	}
+}
+
+class Bar {
+	public static function method() {
+		return true;
+	}
+}
+
+var_dump(Foo::method());
+
+uopz_set_mock(Foo::class, Bar::class);
+
+var_dump(Foo::method());
+?>
+--EXPECTF--
+bool(false)
+bool(true)

--- a/tests/024.phpt
+++ b/tests/024.phpt
@@ -1,0 +1,30 @@
+--TEST--
+init method call non constant method name
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public function method() {
+		return false;
+	}
+}
+
+class Bar {
+	public function method() {
+		return true;
+	}
+}
+
+$foo = new Foo();
+$method = sprintf("method");
+
+var_dump($foo->$method());
+
+uopz_set_mock(Foo::class, Bar::class);
+
+var_dump($foo->$method());
+?>
+--EXPECTF--
+bool(false)
+bool(true)

--- a/tests/025.phpt
+++ b/tests/025.phpt
@@ -1,0 +1,29 @@
+--TEST--
+init static method call non constant method name
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public static function method() {
+		return false;
+	}
+}
+
+class Bar {
+	public static function method() {
+		return true;
+	}
+}
+
+$method = sprintf("method");
+
+var_dump(Foo::$method());
+
+uopz_set_mock(Foo::class, Bar::class);
+
+var_dump(Foo::$method());
+?>
+--EXPECTF--
+bool(false)
+bool(true)

--- a/tests/026.phpt
+++ b/tests/026.phpt
@@ -1,0 +1,31 @@
+--TEST--
+init method call ref method name
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public function method() {
+		return false;
+	}
+}
+
+class Bar {
+	public function method() {
+		return true;
+	}
+}
+
+$foo = new Foo();
+$string = sprintf("method");
+$method = &$string;
+
+var_dump($foo->$method());
+
+uopz_set_mock(Foo::class, Bar::class);
+
+var_dump($foo->$method());
+?>
+--EXPECTF--
+bool(false)
+bool(true)

--- a/tests/027.phpt
+++ b/tests/027.phpt
@@ -1,0 +1,23 @@
+--TEST--
+init method call non string method
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public function method() {
+		return false;
+	}
+}
+
+$foo = new Foo();
+$method = 1;
+
+var_dump($foo->$method());
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Method name must be a string in %s:11
+Stack trace:
+#0 {main}
+  thrown in %s on line 11

--- a/tests/028.phpt
+++ b/tests/028.phpt
@@ -1,0 +1,15 @@
+--TEST--
+init method call non object object
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+$foo = "string";
+
+var_dump($foo->method());
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Call to a member function method() on string in %s:4
+Stack trace:
+#0 {main}
+  thrown in %s on line 4

--- a/tests/029.phpt
+++ b/tests/029.phpt
@@ -1,0 +1,19 @@
+--TEST--
+init method call object ref
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public function method() {
+		return false;
+	}
+}
+
+$object = new Foo();
+$foo = &$object;
+
+var_dump($foo->method());
+?>
+--EXPECTF--
+bool(false)

--- a/tests/030.phpt
+++ b/tests/030.phpt
@@ -1,0 +1,35 @@
+--TEST--
+init static method call self
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public static function method() {
+		return self::internal();
+	}
+
+	private static function internal() {
+		return false;
+	}
+}
+
+class Bar {
+	public static function method() {
+		return self::internal();
+	}
+
+	private static function internal() {
+		return true;
+	}
+}
+
+var_dump(Foo::method());
+
+uopz_set_mock(Foo::class, Bar::class);
+
+var_dump(Foo::method());
+?>
+--EXPECTF--
+bool(false)
+bool(true)

--- a/tests/031.phpt
+++ b/tests/031.phpt
@@ -1,0 +1,30 @@
+--TEST--
+init static method call ref method name
+--SKIPIF--
+<?php include("skipif.inc") ?>
+--FILE--
+<?php
+class Foo {
+	public static function method() {
+		return false;
+	}
+}
+
+class Bar {
+	public static function method() {
+		return true;
+	}
+}
+
+$string = sprintf("method");
+$method = &$string;
+
+var_dump(Foo::$method());
+
+uopz_set_mock(Foo::class, Bar::class);
+
+var_dump(Foo::$method());
+?>
+--EXPECTF--
+bool(false)
+bool(true)

--- a/tests/032.phpt
+++ b/tests/032.phpt
@@ -1,0 +1,35 @@
+--TEST--
+init fcall
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--INI--
+opcache.enable_cli=0
+--FILE--
+<?php
+namespace Moo {
+	function fail() {
+		return none();
+	}
+
+	function say() {
+		return call();
+	}
+
+	function call() {
+		return true;
+	}
+}
+
+namespace {
+	var_dump(Moo\say());
+
+	Moo\fail();
+}
+--EXPECTF--
+bool(true)
+
+Fatal error: Uncaught Error: Call to undefined function Moo\none() in %s:4
+Stack trace:
+#0 %s(19): Moo\fail()
+#1 {main}
+  thrown in %s on line 4

--- a/tests/bugs/gh76.phpt
+++ b/tests/bugs/gh76.phpt
@@ -1,0 +1,37 @@
+--TEST--
+uopz_extend affects only explicit calls via parent:: but not inherited methods
+--SKIPIF--
+
+--FILE--
+<?php
+class A {
+  public function __construct() {
+    echo "A ctor\n";
+  }
+  public function who() {
+    echo "A\n";
+  }
+}
+class B extends A {
+  public function __construct() {
+    echo "B ctor\n";
+    parent::__construct();
+  }
+}
+class MockA {
+  public function __construct() {
+    echo "MockA ctor\n";
+  }
+  public function who() {
+    echo "MockA\n";
+  }
+}
+uopz_extend(B::class, MockA::class);
+$b = new B();
+$b->who();
+?>
+--EXPECT--
+B ctor
+MockA ctor
+MockA
+

--- a/uopz.c
+++ b/uopz.c
@@ -84,7 +84,6 @@ static PHP_MINIT_FUNCTION(uopz)
 	REGISTER_LONG_CONSTANT("ZEND_ACC_ABSTRACT", 			ZEND_ACC_ABSTRACT,				CONST_CS|CONST_PERSISTENT);
 
 	uopz_executors_init();
-	uopz_handlers_init();
 
 	return SUCCESS;
 }
@@ -98,7 +97,6 @@ static PHP_MSHUTDOWN_FUNCTION(uopz)
 	}
 
 	uopz_executors_shutdown();
-	uopz_handlers_shutdown();
 
 	return SUCCESS;
 } /* }}} */
@@ -130,6 +128,8 @@ static PHP_RINIT_FUNCTION(uopz)
 				ce : zend_exception_get_default();
 	zend_string_release(spl);
 
+	/* this is not nice, but makes zend_extension (xdbg,o+) play nicer */
+	uopz_handlers_init();
 	uopz_request_init();
 
 	return SUCCESS;
@@ -144,6 +144,7 @@ static PHP_RSHUTDOWN_FUNCTION(uopz)
 	}
 
 	uopz_request_shutdown();
+	uopz_handlers_shutdown();
 
 	return SUCCESS;
 }


### PR DESCRIPTION
This is a rewrite of the vm integration for uopz ... it improves many things ....

Little bit of justification: uopz invalidated runtime caches in order to function, and while it's the case that this is sufficient a good portion of the time, it means that there are some pretty strange edge cases when trying to use uopz to test legacy code. The edge cases could result in memory errors and faults, of the unavoidable variety. In implementing more of the business logic for handlers we have the opportunity to instrument the vm at the correct time, more of the time and correctly.

This will remain open for another day or so, while I complete testing on work test suites, and try to improve test coverage a bit more ... it will then be merged into master.

On a side note, this merge will drop support for 7.0, it simplifies the code a little in preparation for the additional complexity of 7.4, which we will soon have to support.