### PR TITLE
Add a ini option to control the exit override default

### DIFF
--- a/tests/041.phpt
+++ b/tests/041.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Ensure uopz.allow_exit is respected
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--INI--
+uopz.disable=0
+uopz.allow_exit=1
+--FILE--
+<?php
+exit("exit\n");
+echo "after exit\n";
+--EXPECT--
+exit

--- a/tests/042.phpt
+++ b/tests/042.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Ensure uopz.allow_exit can be overridden
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--INI--
+uopz.disable=0
+uopz.allow_exit=1
+--FILE--
+<?php
+uopz_allow_exit(false);
+exit("exit\n");
+echo "after exit\n";
+--EXPECT--
+after exit

--- a/uopz.c
+++ b/uopz.c
@@ -56,6 +56,7 @@ ZEND_DECLARE_MODULE_GLOBALS(uopz)
 
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("uopz.disable", "0", PHP_INI_SYSTEM, OnUpdateBool, disable, zend_uopz_globals, uopz_globals)
+	STD_PHP_INI_ENTRY("uopz.allow_exit", "0", PHP_INI_SYSTEM, OnUpdateBool, exit, zend_uopz_globals, uopz_globals)
 PHP_INI_END()
 
 /* {{{ */


### PR DESCRIPTION
I would like to enable the extension but still use the `exit()` function. To achieve this I have to add calls to `uopz_allow_exit(true)` everywhere, it would be preferable to control this at the same time as enabling the extension, eg:
```
extension=uopz
uopz.allow_exit=1
```
