### PR TITLE
Remove HAVE_SPL

### DIFF
--- a/uopz.c
+++ b/uopz.c
@@ -24,12 +24,6 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 
-#ifndef HAVE_SPL
-/* {{{ */
-zend_class_entry *spl_ce_RuntimeException;
-zend_class_entry *spl_ce_InvalidArgumentException; /* }}} */
-#endif
-
 #include "uopz.h"
 
 #include "src/util.h"

--- a/uopz.h
+++ b/uopz.h
@@ -44,12 +44,7 @@ ZEND_END_MODULE_GLOBALS(uopz)
 #define UOPZ(v) (uopz_globals.v)
 #endif
 
-#ifdef HAVE_SPL
-#	include "ext/spl/spl_exceptions.h"
-#else
-	extern zend_class_entry* spl_ce_RuntimeException;
-#endif
-
+#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_inheritance.h"
 #include "Zend/zend_exceptions.h"
 #include "Zend/zend_closures.h"


### PR DESCRIPTION
The HAVE_SPL symbol is defined in PHP to indicate the presence of the spl extension. Since PHP 5.3 the spl extension is always availabe and since PHP-7.4 the HAVE_SPL symbol has also been removed.