### PR TITLE
Don't remove methods of immutable classes

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -169,7 +169,12 @@ int uopz_clean_function(zval *zv) { /* {{{ */
 
 int uopz_clean_class(zval *zv) { /* {{{ */
 	zend_class_entry *ce = Z_PTR_P(zv);
-	
+
+#if PHP_VERSION_ID >= 70400
+	if (ce->ce_flags & ZEND_ACC_IMMUTABLE) {
+		return ZEND_HASH_APPLY_KEEP;
+	}
+#endif
 	zend_hash_apply(
 		&ce->function_table, uopz_clean_function);
 	


### PR DESCRIPTION
These are not fully reloaded by OPcache, so the methods would be
missing after the first request shutdown.

Cf. <https://github.com/php/php-src/blob/php-7.4.9/UPGRADING.INTERNALS#L139-L141>.