### PR TITLE
Skip unsupported tests on PHP 7.4+ with OPcache

### DIFF
--- a/tests/016.phpt
+++ b/tests/016.phpt
@@ -6,7 +6,8 @@ include("skipif.inc");
 uopz_allow_exit(true);
 if (version_compare(PHP_VERSION, '7.4', '>=')
 	&& function_exists('opcache_get_status')
-	&& opcache_get_status()['opcache_enabled'])
+	&& ($status = opcache_get_status())
+	&& $status['opcache_enabled'])
 {
 	die('skip not for PHP 7.4+ with OPcache');
 }

--- a/tests/016.phpt
+++ b/tests/016.phpt
@@ -1,7 +1,16 @@
 --TEST--
 uopz_flags
 --SKIPIF--
-<?php include("skipif.inc") ?>
+<?php
+include("skipif.inc");
+uopz_allow_exit(true);
+if (version_compare(PHP_VERSION, '7.4', '>=')
+	&& function_exists('opcache_get_status')
+	&& opcache_get_status()['opcache_enabled'])
+{
+	die('skip not for PHP 7.4+ with OPcache');
+}
+?>
 --INI--
 uopz.disable=0
 --FILE--

--- a/tests/bugs/gh76.phpt
+++ b/tests/bugs/gh76.phpt
@@ -6,7 +6,8 @@ include(__DIR__ . '/../skipif.inc');
 uopz_allow_exit(true);
 if (version_compare(PHP_VERSION, '7.4', '>=')
 	&& function_exists('opcache_get_status')
-	&& opcache_get_status()['opcache_enabled'])
+	&& ($status = opcache_get_status())
+	&& $status['opcache_enabled'])
 {
 	die('skip not for PHP 7.4+ with OPcache');
 }

--- a/tests/bugs/gh76.phpt
+++ b/tests/bugs/gh76.phpt
@@ -3,6 +3,13 @@ uopz_extend affects only explicit calls via parent:: but not inherited methods
 --SKIPIF--
 <?php
 include(__DIR__ . '/../skipif.inc');
+uopz_allow_exit(true);
+if (version_compare(PHP_VERSION, '7.4', '>=')
+	&& function_exists('opcache_get_status')
+	&& opcache_get_status()['opcache_enabled'])
+{
+	die('skip not for PHP 7.4+ with OPcache');
+}
 ?>
 --INI--
 uopz.disable=0


### PR DESCRIPTION
As of PHP 7.4.0, uopz can no longer support manipulation of immutable
classes and functions when OPcache is enabled.  Therefore, we skip the
respective test cases under these conditions.

We also have to make sure that the `die()`s are actually executed.