### PR TITLE
Basic GH Actions CI for building and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: Build and Test
+on: [push, pull_request]
+jobs:
+  ubuntu:
+    strategy:
+      matrix:
+        version: ["8.0", "8.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout uopz
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{matrix.version}}
+          extensions: :xdebug
+          ini-values: opcache.enable_cli=1
+      - name: phize
+        run: phpize
+      - name: configure
+        run: ./configure --enable-uopz
+      - name: make
+        run: make
+      - name: test
+        run: make test TESTS=tests
+  windows:
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      matrix:
+          version: ["8.0", "8.1"]
+          arch: [x64, x86]
+          ts: [nts, ts]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout uopz
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        id: setup-php
+        uses: cmb69/setup-php-sdk@v0.1
+        with:
+          version: ${{matrix.version}}
+          arch: ${{matrix.arch}}
+          ts: ${{matrix.ts}}
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.arch}}
+          toolset: ${{steps.setup-php.outputs.toolset}}
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: configure --enable-uopz --with-prefix=${{steps.setup-php.outputs.prefix}}
+      - name: make
+        run: nmake
+      - name: test
+        run: nmake test TESTS=tests


### PR DESCRIPTION
No OPcache yet.

---

Windows runs are slow due to lack of caching of the setup-php-sdk action; I'll hope I find some time to improve that. Anyway, might be good as is for now ( https://github.com/cmb69/uopz/actions/runs/1076352401) to close #148.