### PR TITLE
#163 Fix case-sensitivity issue in uopz_get_return()

### DIFF
--- a/src/return.c
+++ b/src/return.c
@@ -101,6 +101,7 @@ zend_bool uopz_unset_return(zend_class_entry *clazz, zend_string *function) { /*
 } /* }}} */
 
 void uopz_get_return(zend_class_entry *clazz, zend_string *function, zval *return_value) { /* {{{ */
+	zend_string *key;
 	HashTable *returns;
 	uopz_return_t *ureturn;
 
@@ -112,7 +113,7 @@ void uopz_get_return(zend_class_entry *clazz, zend_string *function, zval *retur
 		return;
 	}
 
-	zend_string *key = zend_string_tolower(function);
+	key = zend_string_tolower(function);
 	ureturn = zend_hash_find_ptr(returns, key);
 	zend_string_release(key);
 

--- a/src/return.c
+++ b/src/return.c
@@ -112,7 +112,9 @@ void uopz_get_return(zend_class_entry *clazz, zend_string *function, zval *retur
 		return;
 	}
 
-	ureturn = zend_hash_find_ptr(returns, function);
+	zend_string *key = zend_string_tolower(function);
+	ureturn = zend_hash_find_ptr(returns, key);
+	zend_string_release(key);
 
 	if (!ureturn) {
 		return;

--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -10,6 +10,10 @@ class Foo {
 	public function bar() {
 		return false;	
 	}
+
+	public function bazQuux() {
+		return false;
+	}
 }
 
 var_dump(uopz_set_return(Foo::class, "bar", true));
@@ -21,6 +25,14 @@ var_dump(uopz_set_return(Foo::class, "bar", function(){}));
 var_dump(uopz_get_return(Foo::class, "bar"));
 
 var_dump(uopz_get_return(Foo::class, "nope"));
+
+var_dump(uopz_set_return(Foo::class, "bazQuux", true));
+
+var_dump(uopz_get_return(Foo::class, "bazQuux"));
+
+var_dump(uopz_set_return(Foo::class, "bazQuux", function(){}));
+
+var_dump(uopz_get_return(Foo::class, "bazQuux"));
 ?>
 --EXPECT--
 bool(true)
@@ -29,3 +41,8 @@ bool(true)
 object(Closure)#1 (0) {
 }
 NULL
+bool(true)
+bool(true)
+bool(true)
+object(Closure)#2 (0) {
+}


### PR DESCRIPTION
- uopz_get_return() [return.c] now uses the lower-case of the function name as the hash key
- updated 002.phpt to cover case of method with upper-case chars in name