### PR TITLE
fix #172: handle ZEND_VERIFY_NEVER_TYPE when uopz.exit is disabled

### DIFF
--- a/tests/bugs/gh172.phpt
+++ b/tests/bugs/gh172.phpt
@@ -1,0 +1,29 @@
+--TEST--
+handle ZEND_VERIFY_NEVER_TYPE when uopz.exit disabled
+--EXTENSIONS--
+uopz
+--INI--
+uopz.disable=0
+uopz.exit=0
+opcache.enable_cli=0
+xdebug.enable=0
+--FILE--
+<?php
+
+function x(): never {
+  exit(10);
+}
+
+x();
+
+var_dump(uopz_get_exit_status());
+
+uopz_allow_exit(true);
+
+exit(20);
+
+echo "not here\n";
+
+?>
+--EXPECT--
+int(10)

--- a/tests/bugs/gh172.phpt
+++ b/tests/bugs/gh172.phpt
@@ -1,12 +1,13 @@
 --TEST--
 handle ZEND_VERIFY_NEVER_TYPE when uopz.exit disabled
---SKIPIF--
-<?php
-if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-  die("skip: PHP 8.1+ only");
-}
 --EXTENSIONS--
 uopz
+--SKIPIF--
+<?php
+uopz_allow_exit(true);
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+  die("skip PHP 8.1+ only");
+}
 --INI--
 uopz.disable=0
 uopz.exit=0
@@ -15,6 +16,7 @@ xdebug.enable=0
 --FILE--
 <?php
 
+uopz_allow_exit(false);
 function x(): never {
   exit(10);
 }

--- a/tests/bugs/gh172.phpt
+++ b/tests/bugs/gh172.phpt
@@ -1,5 +1,10 @@
 --TEST--
 handle ZEND_VERIFY_NEVER_TYPE when uopz.exit disabled
+--SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+  die("skip: PHP 8.1+ only");
+}
 --EXTENSIONS--
 uopz
 --INI--

--- a/tests/bugs/gh172a.phpt
+++ b/tests/bugs/gh172a.phpt
@@ -1,12 +1,13 @@
 --TEST--
 do not handle ZEND_VERIFY_NEVER_TYPE if not uopz_allow_exit
---SKIPIF--
-<?php
-if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-  die("skip: PHP 8.1+ only");
-}
 --EXTENSIONS--
 uopz
+--SKIPIF--
+<?php
+uopz_allow_exit(true);
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+  die("skip PHP 8.1+ only");
+}
 --INI--
 uopz.disable=0
 uopz.exit=1

--- a/tests/bugs/gh172a.phpt
+++ b/tests/bugs/gh172a.phpt
@@ -1,5 +1,10 @@
 --TEST--
 do not handle ZEND_VERIFY_NEVER_TYPE if not uopz_allow_exit
+--SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+  die("skip: PHP 8.1+ only");
+}
 --EXTENSIONS--
 uopz
 --INI--

--- a/tests/bugs/gh172a.phpt
+++ b/tests/bugs/gh172a.phpt
@@ -1,0 +1,20 @@
+--TEST--
+do not handle ZEND_VERIFY_NEVER_TYPE if not uopz_allow_exit
+--EXTENSIONS--
+uopz
+--INI--
+uopz.disable=0
+uopz.exit=1
+opcache.enable_cli=0
+xdebug.enable=0
+--FILE--
+<?php
+
+function x(): never {
+  return "here";
+}
+x();
+
+?>
+--EXPECTF--
+Fatal error: A never-returning function must not return in %s

--- a/uopz.h
+++ b/uopz.h
@@ -51,6 +51,10 @@ ZEND_END_MODULE_GLOBALS(uopz)
 #define uopz_exception(message, ...) zend_throw_exception_ex\
 	(spl_ce_RuntimeException, 0, message, ##__VA_ARGS__)
 
+#if PHP_VERSION_ID < 80100
+#define ZEND_VERIFY_NEVER_TYPE         201
+#endif
+
 #endif	/* UOPZ_H */
 
 /*


### PR DESCRIPTION
This should handle #172

When `uopz.exit` is disabled, actual call to `exit()` implicitly returns and violates never return type check.

I'd appreciate it if @cmb69 or @remicollet could check it / merge it. Thanks!
