### PR TITLE
Normalize Autoconf code

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -8,23 +8,28 @@ PHP_ARG_WITH(uopz-sanitize, whether to enable AddressSanitizer for uopz,
 [  --with-uopz-sanitize Build uopz with AddressSanitizer support], no, no)
 
 if test "$PHP_UOPZ" != "no"; then
-  if test "$PHP_UOPZ_SANITIZE" != "no"; then
+  AS_VAR_IF([PHP_UOPZ_SANITIZE], [no],, [
     EXTRA_LDFLAGS="-lasan"
-	EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
-	PHP_SUBST(EXTRA_LDFLAGS)
-    PHP_SUBST(EXTRA_CFLAGS)
-  fi
+    EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+    PHP_SUBST([EXTRA_LDFLAGS])
+    PHP_SUBST([EXTRA_CFLAGS])
+  ])
 
-  PHP_NEW_EXTENSION(uopz, uopz.c src/util.c src/return.c src/hook.c src/constant.c src/function.c src/class.c src/handlers.c src/executors.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_ADD_BUILD_DIR($ext_builddir/src, 1)
-  PHP_ADD_INCLUDE($ext_builddir)
+  PHP_NEW_EXTENSION([uopz], m4_normalize([
+      src/class.c
+      src/constant.c
+      src/executors.c
+      src/function.c
+      src/handlers.c
+      src/hook.c
+      src/return.c
+      src/util.c
+      uopz.c
+    ]),
+    [$ext_shared],,
+    [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+  PHP_ADD_BUILD_DIR([$ext_builddir/src])
+  PHP_ADD_INCLUDE([$ext_builddir])
 
-  AC_MSG_CHECKING([uopz coverage])
-  if test "$PHP_UOPZ_COVERAGE" != "no"; then
-    AC_MSG_RESULT([enabled])
-
-    PHP_ADD_MAKEFILE_FRAGMENT
-  else
-    AC_MSG_RESULT([disabled])
-  fi
+  AS_VAR_IF([PHP_UOPZ_COVERAGE], [no],, [PHP_ADD_MAKEFILE_FRAGMENT])
 fi


### PR DESCRIPTION
- All arguments quoted
- AS_* macros used where appropriate
- m4_normalize trims list items together into a space separated list of items
- duplicate checking message whether opz coverage is enabled simplified
- PHP_ADD_BUILD_DIR 2nd argument was redundant as the build directory is created automatically at the end of the configure phase by phpize M4 code