### PR TITLE
Added PIE support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "krakjoe/uopz",
+    "type": "php-ext",
+    "license": "MIT",
+    "description": "User Operations for Zend",
+    "require": {
+        "php": "^8.0"
+    },
+    "php-ext": {
+        "extension-name": "uopz",
+        "configure-options": [
+            {
+                "name": "enable-uopz",
+                "description": "whether to enable uopz support"
+            },
+            {
+                "name": "enable-uopz-coverage",
+                "description": "whether to enable uopz coverage support"
+            },
+            {
+                "name": "with-uopz-sanitize",
+                "needs-value": true,
+                "description": "whether to enable AddressSanitizer for uopz"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds support for [PIE](https://github.com/php/pie).

Once merged, a maintainer would need to add this repo's URL to https://packagist.org/packages/submit :)

More info/documentation can be read on: https://github.com/php/pie/blob/main/docs/extension-maintainers.md